### PR TITLE
fix: resolve high severity minimatch ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
+  "resolutions": {
+    "minimatch": "^3.1.3"
+  },
   "volta": {
     "node": "20.15.1",
     "yarn": "1.22.22"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,10 @@ make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-minimatch@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimatch@^3.1.1, minimatch@^3.1.3:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 


### PR DESCRIPTION
## Summary
- Resolves 1 open high-severity Dependabot alert for `minimatch` (ReDoS via matchOne() combinatorial backtracking)
- Added yarn `resolutions` to pin `minimatch` to `^3.1.3` (resolved to `3.1.5`)

## Changes
- `package.json`: Added `resolutions` block for `minimatch`
- `yarn.lock`: Updated `minimatch` from `3.1.2` -> `3.1.5`

## Verification
- `yarn install` completes successfully
- `yarn build` compiles without errors
- No direct dependency changes, only transitive dependency pinning

## Dependabot Alert
- [GHSA] minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments

Made with [Cursor](https://cursor.com)